### PR TITLE
Remove titles from blog posts on ADK and LangExtract to streamline co…

### DIFF
--- a/_posts/adk.md
+++ b/_posts/adk.md
@@ -6,8 +6,6 @@ category: 'Getting Started'
 author: 'Thomas Chong'
 ---
 
-# Mastering AgentOps: A Deep Dive into Evaluating ADK Agents with Langfuse
-
 ### The Challenge of Production-Ready Agents
 
 The era of AI agents is upon us. Building a proof-of-concept agent that can chat or perform a simple task has become remarkably accessible. However, the journey from a clever prototype to a reliable, production-grade application is fraught with challenges. How do you ensure your agent behaves predictably? How do you measure its performance over time and prevent regressions when you update a prompt or a tool? Answering these questions requires moving beyond simple "vibe-testing" and adopting a more rigorous, engineering-focused discipline.

--- a/_posts/langextract_with_google_adk.md
+++ b/_posts/langextract_with_google_adk.md
@@ -6,8 +6,6 @@ category: 'Getting Started'
 author: 'Thomas Chong'
 ---
 
-# Supercharging AI Agents: A Practical Guide to Integrating LangExtract with the Google ADK
-
 Extracting structured data from unstructured text—like emails or reports—is a common challenge. **LangExtract** is an open-source Python library from Google that uses Large Language Models (LLMs) to accurately extract entities, relationships, and other structured information from raw text. It also provides traceability, so you can see exactly where each piece of data came from in the original document.
 
 Now, imagine giving this extraction power to an AI agent that can reason and act. The **Google Agent Development Kit (ADK)** lets you build such agents.


### PR DESCRIPTION
…ntent presentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined two blog posts by removing redundant in-page H1 titles; pages now show a single title from metadata and begin directly with the first section.
  * Added a clear introductory sentence to the LangExtract + Google ADK guide to set expectations and improve readability.
  * Improved overall consistency and clarity without altering core content or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->